### PR TITLE
Enhancement for ability to serve  embedded.

### DIFF
--- a/_files/config/config.php
+++ b/_files/config/config.php
@@ -5,6 +5,7 @@
 return array (
   //'root' => '',
   //'start_path' => false,
+  //'script' => null,
   //'username' => '',
   //'password' => '',
   //'load_images' => true,

--- a/index.php
+++ b/index.php
@@ -2349,7 +2349,7 @@ foreach (array_filter([
 
     // return Javascript config array, merged (some values overridden) with main $config
     return array_replace($config, [
-      'script' => U::basename(__FILE__), // so JS knows where to post
+      'script' => Config::$config['script'] ?? U::basename(__FILE__), // so JS knows where to post
       'menu_exists' => $this->menu_exists, // so JS knows if menu exists
       'menu_cache_hash' => $this->menu_cache_hash, // hash to post from JS when loading menu to check cache
       'menu_cache_file' => $this->menu_cache_file, // direct url to JSON menu cache file if !menu_cache_validate


### PR DESCRIPTION
Added one liner change to the returned Javascript config array to use the script value provided within the custom config file (i.e _filesconfig.php); so that if such `script` value present the javascripts will use it instead of default  U:basename(__FILE__), otherwise it will be used as default, as before. 

Rational for this, i am serving the php within a slim framework, under a dedicated route, so i needed to js to use the initial route not the basenamed file.  Here is the sample
```
    public function filemanager($request, $response, $args){
       
        include __DIR__.'/filemanager/index.php';
        return $response;
    }
```

And by adding below into `_filesconfig.php`, 
```
'script'=>'',
```
the route worked perfectly. 

Pls consider. 

